### PR TITLE
chore: bump org.apache.commons:commons-compress from 1.26.2 to 1.27.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <!-- do not update necessary for lesson -->
     <checkstyle.version>3.4.0</checkstyle.version>
     <commons-collections.version>3.2.1</commons-collections.version>
-    <commons-compress.version>1.26.2</commons-compress.version>
+    <commons-compress.version>1.27.1</commons-compress.version>
     <commons-io.version>2.16.1</commons-io.version>
     <commons-lang3.version>3.14.0</commons-lang3.version>
     <commons-text.version>1.12.0</commons-text.version>


### PR DESCRIPTION
Bumps org.apache.commons:commons-compress from 1.26.2 to 1.27.1.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-compress dependency-type: direct:production update-type: version-update:semver-minor ...

Thank you for submitting a pull request to the WebGoat!
